### PR TITLE
Changed URL and data source for ARG-ANNOT

### DIFF
--- a/bin/abricate-get_db
+++ b/bin/abricate-get_db
@@ -286,10 +286,12 @@ sub get_megares {
 
 #..............................................................................
 sub get_argannot {
+  # the website at www.mediterranee-infection.com has been reorganised, file is pulled from a 'mirror' backup site. Updated to May '18 release
   my $fasta = 'arg-annot.fa';
   download(
 #    'http://www.mediterranee-infection.com/arkotheque/client/ihumed/_depot_arko/articles/1425/argannot-aa-v3-march2017_doc.fasta',
-    'http://www.mediterranee-infection.com/arkotheque/client/ihumed/_depot_arko/articles/691/argannot-nt_doc.fasta',
+#    'http://www.mediterranee-infection.com/arkotheque/client/ihumed/_depot_arko/articles/691/argannot-nt_doc.fasta',
+     'http://backup.mediterranee-infection.com/arkotheque/client/ihumed/_depot_arko/articles/2042/arg-annot-v4-nt-may2018_doc.fasta',
     $fasta
   );
   


### PR DESCRIPTION
Due to the reorganisation of the website at https://www.mediterranee-infection.com/, the ARG-ANNOT source files are no longer available. A backup 'mirror' server (http://backup.mediterranee-infection.com/) still serves the file. The URL also now points to the May 2018 NT release -  save_fasta writes 2020 sequences from this release after deduplication. Should resolve #79 