### PR TITLE
Abort on non-zero blastcmd exit code

### DIFF
--- a/bin/abricate
+++ b/bin/abricate
@@ -121,12 +121,13 @@ for my $file (@ARGV) {
                : "blastx -task blastx-fast -seg no"
                ;
 
-  my $cmd = "(any2fasta -q -u \Q$file\E |"
-          . " $blastcmd -db \Q$db_path\E -outfmt '$format' -num_threads $threads"
+  my $cmd = "bash -c 'set -euo pipefail;"
+          . " any2fasta -q -u \Q$file\E |"
+          . " $blastcmd -db \Q$db_path\E -outfmt '" . "$format" . "' -num_threads $threads"
           . " -evalue 1E-20 -culling_limit $CULL"
           . " -max_target_seqs 10000"  # https://github.com/tseemann/abricate/issues/135
 #          . " -max_target_seqs ".$dbinfo->{SEQUENCES}   # Issue #76
-          . ")"
+          . "'"
           ;
 
   msg("Running: $cmd") if $debug;
@@ -183,6 +184,12 @@ for my $file (@ARGV) {
     ];
   }
   close BLAST;
+  # Check the exit status of BLAST handle and abort
+  my $exitcode = $? >> 8;
+  if ($exitcode != 0) {
+      msg("Command exited with non-zero exit code $exitcode. Aborting Abricate.");
+      exit($exitcode);
+  }
 
   msg("Found", scalar(@hit), "genes in $file");
 


### PR DESCRIPTION
Currently, Abricate will exit successfully regardless of the exit code of the BLAST command. This is misleading as failures in the BLAST command (eg. if it is killed by the OOM killer) will emit the message "Found 0 genes in <file>", rather than indicating an error has ocurred.

This change checks the exit code of the executed command after `close` is called. If it is non-zero, Abricate will terminate with a brief message and the same exit code; allowing the calling shell to decide what to do with the error.

This change uses a bash subshell instead of sh to make use of pipefail. For anyone who wants to continue using sh I wave my hands in the air and leave it as an exercise to anyone who wishes to inspect the exit code of each piped command instead.

I leave this around in the hope it may be useful for someone!